### PR TITLE
letの型推論を修正

### DIFF
--- a/ng_testcase.txt
+++ b/ng_testcase.txt
@@ -1,4 +1,0 @@
-(* Expected: ('a -> ('a -> 'a) -> bool) -> 'a -> ('a -> 'a) -> 'a *)
-fun x -> fun y -> fun z -> let b = x y z in if b then z y else y;;
-(* Expected: Type Error *)
-fun x -> fun y -> fun z -> let b = x y z in if b then z y else z x;;

--- a/typing.ml
+++ b/typing.ml
@@ -89,7 +89,9 @@ let rec ty_exp tyenv = function
     let (s1, ty1) = ty_exp tyenv exp1 in
     let newtyenv = Environment.extend id ty1 tyenv in
     let (s2, ty2) = ty_exp newtyenv exp2 in
-    (s2, ty2)
+    let eqs = (eqs_of_subst s1) @ (eqs_of_subst s2) @ [(ty1, ty2)] in
+    let s3 = unify eqs in
+    (s3, subst_type s3 ty1)
   | FunExp (id, exp) ->
     let domty = TyVar (fresh_tyvar ()) in
     let s, ranty =

--- a/typing.ml
+++ b/typing.ml
@@ -89,9 +89,9 @@ let rec ty_exp tyenv = function
     let (s1, ty1) = ty_exp tyenv exp1 in
     let newtyenv = Environment.extend id ty1 tyenv in
     let (s2, ty2) = ty_exp newtyenv exp2 in
-    let eqs = (eqs_of_subst s1) @ (eqs_of_subst s2) @ [(ty1, ty2)] in
+    let eqs = (eqs_of_subst s1) @ (eqs_of_subst s2) in
     let s3 = unify eqs in
-    (s3, subst_type s3 ty1)
+    (s3, subst_type s3 ty2)
   | FunExp (id, exp) ->
     let domty = TyVar (fresh_tyvar ()) in
     let s, ranty =


### PR DESCRIPTION
#1 を修正。

これで（let多相を導入しない場合の）必修課題分のテスト（http://www.fos.kuis.kyoto-u.ac.jp/~umatani/le3b/testcases.html ）がすべて通るようになる。